### PR TITLE
Update ScriptDom version to support VS 18.7 and later only

### DIFF
--- a/src/SqlFormatter.csproj
+++ b/src/SqlFormatter.csproj
@@ -106,7 +106,7 @@
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom">
-      <Version>170.179.0</Version>
+      <Version>180.18.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="18.5.40034">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -11,14 +11,11 @@
         <Tags>sql, tsql, formatter, database</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[18.7,)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[18.7,)" >
             <ProductArchitecture>arm64</ProductArchitecture>
-        </InstallationTarget>
-        <InstallationTarget Id="Microsoft.VisualStudio.Ssms" Version="[22.0,)">
-            <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
     </Installation>
     <Prerequisites>

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -11,10 +11,10 @@
         <Tags>sql, tsql, formatter, database</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[18.7,)">
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[18.0,)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[18.7,)" >
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[18.0,)" >
             <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
     </Installation>


### PR DESCRIPTION
Updated Microsoft.SqlServer.TransactSql.ScriptDom to 180.18.1. Changed Visual Studio Community installation target to require version 18.7 or later for both amd64 and arm64.

Removed SSMS installation target from the VSIX manifest.

fixes #31